### PR TITLE
Fix stray ampersand in metadata.xml

### DIFF
--- a/dev-util/hotspot/metadata.xml
+++ b/dev-util/hotspot/metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-	<longdescription>This project is a KDAB R&D effort to create a standalone GUI for performance data. As the first goal, we want to provide a UI like KCachegrind around Linux perf. Looking ahead, we intend to support various other performance data formats under this umbrella.</longdescription>
+	<longdescription>This project is a KDAB R&amp;D effort to create a standalone GUI for performance data. As the first goal, we want to provide a UI like KCachegrind around Linux perf. Looking ahead, we intend to support various other performance data formats under this umbrella.</longdescription>
 </pkgmetadata>


### PR DESCRIPTION
This, for example, prevented 'equery uses hotspot' from running:

    $ equery u hotspot
    Traceback (most recent call last):
      File "/usr/lib/python-exec/python3.13/equery", line 44, in <module>
        equery.main(sys.argv)
        ~~~~~~~~~~~^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/gentoolkit/equery/__init__.py", line 361, in main
        loaded_module.main(module_args)
        ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/gentoolkit/equery/uses.py", line 340, in main
        output = get_output_descriptions(pkg, global_usedesc)
      File "/usr/lib/python3.13/site-packages/gentoolkit/equery/uses.py", line 198, in get_output_descriptions
        if pkg.metadata is None:
           ^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/gentoolkit/package.py", line 137, in metadata
        self._metadata = MetaDataXML(metadata_path, projects_path)
                         ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/site-packages/portage/xml/metadata.py", line 194, in __init__
        self._xml_tree = etree.parse(
                         ~~~~~~~~~~~^
            _unicode_encode(
            ^^^^^^^^^^^^^^^^
        ...<2 lines>...
            parser=etree.XMLParser(target=_MetadataTreeBuilder()),
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        )
        ^
      File "/usr/lib/python3.13/xml/etree/ElementTree.py", line 1204, in parse
        tree.parse(source, parser)
        ~~~~~~~~~~^^^^^^^^^^^^^^^^
      File "/usr/lib/python3.13/xml/etree/ElementTree.py", line 572, in parse
        parser.feed(data)
        ~~~~~~~~~~~^^^^^^
    xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 4, column 44
